### PR TITLE
Change how multiline statements are parsed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "matlab-in-vscode",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "matlab-in-vscode",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "license": "MIT",
             "dependencies": {
                 "vsce": "^2.15.0"

--- a/pybackend/matlab_engine.py
+++ b/pybackend/matlab_engine.py
@@ -1,69 +1,80 @@
 import os
 import sys
-import select
-global import_fail
-try:  # Check if the Matlab Engine is installed
+import re
+
+# Check if the Matlab Engine is installed
+try:
     import matlab.engine
     from matlab.engine import RejectedExecutionError as MatlabTerminated
 except ImportError:
     print("MATLAB Engine for Python cannot be detected. Please install it for the extension to work.")
-    import_fail = True
-else:
-    import_fail = False
+    sys.exit(1)
 
 
 class MatlabEngine:
     def __init__(self):
-        if not import_fail:
-            try:
-                self.eng = matlab.engine.start_matlab('-nodesktop -nosplash')
-                print('-'*20 + "MATLAB Engine for Python is ready." + '-'*20)
-            except MatlabTerminated as e:
-                print(str(e))
-                print("MATLAB Engine for Python exited prematurely.")
+        try:
+            self.eng = matlab.engine.start_matlab("-nodesktop -nosplash")
+            welcome_str = "MATLAB Engine for Python is ready (terminate with 'quit')"
+            print("{0}\n{1}\n{0}".format("-" * len(welcome_str), welcome_str))
+        except MatlabTerminated as e:
+            print("MATLAB Engine for Python exited prematurely:\n{}".format(str(e)))
+
+    def __del__(self):
+        print("Terminating MATLAB Engine.")
+        self.eng.quit()
 
     def clear(self):
-        os.system('cls' if os.name == 'nt' else 'clear')
+        os.system("cls" if os.name == "nt" else "clear")
 
-    def get_input(self):
-        print('\r>>> ', end='')
-        command = input()
-        while True:
-            rlist, _, _ = select.select([sys.stdin], [], [], 0.1)
-            if rlist:
-                command += '\n' + input()
-            else:
-                break
-        return command
+    def get_input(self) -> str:
+        command = sys.stdin.readline()
+
+        # Skip parsing comments
+        if "%" in command:
+            command = command.split("%", 1)[0]
+
+        # Handle multi-line functionality for control structures:
+        pattern = r"\b(if|for|while|switch|try|parfor|function)\b"
+        if re.search(pattern, command):
+            while True:
+                line = self.get_input()
+                command += line + "\n"
+                if line == "end":
+                    break
+        elif command.rstrip().endswith("..."):
+            line = self.get_input()
+            command += line + "\n"
+
+        return command.strip()
 
     def interactive_loop(self):
-        loop = True
-        while loop and not import_fail:
+        while True:
+            # Await input command
+            print("\r>>> ", end="")
             try:
                 command = self.get_input()
-            except:
-                pass
+            except KeyboardInterrupt:
+                print("CTRL+C")
+                continue
 
-            if command == "quit":
-                loop = False
+            # Keyword to terminate the engine
+            if command == "quit" or command == "quit()":
+                break
+            # Keyword to clear terminal
+            elif command == "clc" or command == "clc()":
+                self.clear()
+            # Evaluate command in MATLAB
             else:
                 try:
                     self.eng.eval(command, nargout=0)
-                    if "clc\n" in command:
-                        self.clear()
-                except MatlabTerminated:
-                    print("MATLAB process terminated.")
-                    print("Restarting MATLAB Engine for Python...")
-                    self.eng = matlab.engine.start_matlab()
-                    print("Restarted MATLAB process.")
-
-                except:
+                except MatlabTerminated as e:
+                    print("MATLAB Engine for Python exited prematurely:\n{}".format(str(e)))
+                    break
+                except:  # The other exceptions are handled by MATLAB
                     pass
 
-        if not import_fail:
-            self.eng.quit()
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     matlab_engine = MatlabEngine()
     matlab_engine.interactive_loop()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,6 @@ export function activate(context: vscode.ExtensionContext) {
         }
         else {
             matlabTerminal = startMatlab();
-            // matlabTerminal.sendText(command);
         }
     }
 
@@ -105,7 +104,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
     }
 
-    function interupt() {
+    function interruptMatlab() {
         let matlabTerminal = findMatlabTerminal();
         if (matlabTerminal !== undefined) {
             // send ctrl+c
@@ -145,8 +144,8 @@ export function activate(context: vscode.ExtensionContext) {
     let dispRunMatlabCell = vscode.commands.registerCommand("matlab-in-vscode.runMatlabCell", () => {
         runMatlabCell();
     });
-    let dispInteruptMatlab = vscode.commands.registerCommand("matlab-in-vscode.interupt", () => {
-        interupt();
+    let dispInterruptMatlab = vscode.commands.registerCommand("matlab-in-vscode.interupt", () => {
+        interruptMatlab();
     });
     let dispStopMatlab = vscode.commands.registerCommand("matlab-in-vscode.stop", () => {
         stopMatlab();
@@ -164,7 +163,7 @@ export function activate(context: vscode.ExtensionContext) {
         showMatlabDoc();
     });
 
-    context.subscriptions.push(dispInteruptMatlab);
+    context.subscriptions.push(dispInterruptMatlab);
     context.subscriptions.push(dispRunMatlabCell);
     context.subscriptions.push(dispRunMatlabFile);
     context.subscriptions.push(dispStopMatlab);


### PR DESCRIPTION
Changes the way the python backend handles multiline statements. Now it checks for a regex match with one of the following control statements: pattern = r"\b(if|for|while|switch|try|parfor|function)\b"

If the command contains such a pattern, it will keep expecting inputs until the next 'end' statement.