### PR TITLE
Add startup command to python

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
                 },
                 "matlab-in-vscode.matlabStartup": {
                     "type": "array",
-                    "default": [],
+                    "default": [
+                        "fprintf('Working directory: %s\\n', pwd);"
+                    ],
                     "description": "Arguments to pass to matlab"
                 }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,24 +37,24 @@ export function activate(context: vscode.ExtensionContext) {
 
             let config = vscode.workspace.getConfiguration('matlab-in-vscode');
             let matlabPybackend = config.get('matlabPybackend') as boolean;
-            let command = "";
+            let matlabStartup = config.get('matlabStartup') as string;
+            
+            let startupCommand = "";
+            for (let i = 0; i < matlabStartup.length; i++) {
+                startupCommand += matlabStartup[i];
+            }
+            
+            let bringupCommand = "";
             if (matlabPybackend) {
                 let scriptPath = path.join(context.asAbsolutePath(""), "/pybackend/matlab_engine.py");
-                // matlabTerminal.sendText('python ' + scriptPath, true);
-                command += 'python ' + scriptPath + '\n';
+                bringupCommand = `python ${scriptPath} --cmd="""${startupCommand}"""\n`;
             }
             else {
                 let matlabCMD = config.get('matlabCMD') as string;
-                // matlabTerminal.sendText(matlabCMD, true);
-                command += matlabCMD + '\n';
+                bringupCommand = matlabCMD + '\n' + startupCommand + '\n';
             }
 
-            let matlabStartup = config.get('matlabStartup') as string;
-            for (let i = 0; i < matlabStartup.length; i++) {
-                // matlabTerminal.sendText(matlabStartup[i], true);
-                command += matlabStartup[i] + '\n';
-            }
-            matlabTerminal.sendText(command);
+            matlabTerminal.sendText(bringupCommand);
         }
         matlabTerminal.show(true);
         return matlabTerminal;


### PR DESCRIPTION
A command line parser was added to the python matlab engine wrapper. Any MatLab commands parsed as the --cmd argument will be run after matlab is booted, prior to the terminal becoming interactive.
Maybe this should be done by parsing a script in the future e.g. by adding an extra argument option: --cmdfile=<script_path>.