### PR TITLE
fix: #46

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "matlab-in-vscode",
-    "version": "0.5.1",
+    "version": "0.4.12",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "matlab-in-vscode",
-            "version": "0.5.1",
+            "version": "0.4.12",
             "license": "MIT",
             "dependencies": {
                 "csv-parser": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "matlab-in-vscode",
-    "version": "0.4.11",
+    "version": "0.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "matlab-in-vscode",
-            "version": "0.4.11",
+            "version": "0.5.1",
             "license": "MIT",
             "dependencies": {
                 "csv-parser": "^3.0.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -281,6 +281,10 @@ export function activate(context: vscode.ExtensionContext) {
         // matlabTerminal.sendText("variable_info;");
         // read tmp.csv and display it in the webview
         let workspacePath = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
+        let filePath = vscode.window.activeTextEditor?.document.fileName;
+        if (filePath !== undefined) {
+            workspacePath = path.dirname(filePath);
+        }
         if (workspacePath === undefined) {
             return;
         }
@@ -480,4 +484,5 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() {
+}


### PR DESCRIPTION
摘要
由于matlab工作区的目录和vscode工作区的目录不总是一样的，导致“matlabInVSCodeVariableInfo.csv” 的 创建 和 读取 目录不在同一个位置，会引起 Variable Scope 功能失效。通过调整读取目录，可以修复该bug。

```MATLAB
        let filePath = vscode.window.activeTextEditor?.document.fileName;
        if (filePath !== undefined) {
            workspacePath = path.dirname(filePath);
        }
```